### PR TITLE
Fix issue with dartdevc

### DIFF
--- a/lib/src/formatters/Formatter.dart
+++ b/lib/src/formatters/Formatter.dart
@@ -1,6 +1,6 @@
 part of sprintf;
 
-class Formatter {
+abstract class Formatter {
 
   var fmt_type;
   var options;
@@ -19,4 +19,6 @@ class Formatter {
 
     return padding.toString();
   }
+
+  String asString();
 }

--- a/lib/src/sprintf_impl.dart
+++ b/lib/src/sprintf_impl.dart
@@ -1,12 +1,12 @@
 part of sprintf;
 
-typedef PrintFormatFormatter(arg, options);
+typedef Formatter PrintFormatFormatter(arg, options);
 
 class PrintFormat {
   static final RegExp specifier = new RegExp(r'%(?:(\d+)\$)?([\+\-\#0 ]*)(\d+|\*)?(?:\.(\d+|\*))?([a-z%])', caseSensitive : false);
   static final RegExp uppercase_rx = new RegExp(r'[A-Z]', caseSensitive: true);
 
-  var _formatters = {
+  Map<String, PrintFormatFormatter> _formatters = {
     'i' : (arg, options) => new IntFormatter(arg, 'i', options),
     'd' : (arg, options) => new IntFormatter(arg, 'd', options),
     'x' : (arg, options) => new IntFormatter(arg, 'x', options),


### PR DESCRIPTION
I fixed some weak typing that was blocking compilation with dartdevc. The type of `_formatters` could not be inferred, so the analyzer did not warn that `asString` is not a method that belongs to all formatters. I changed the definition of `PrintFormatFormatter` so that the return value is always a `Formatter`. And I added the `asString` method to the formatter class. Also I made that class abstract since I think it is supposed to be abstract.

Could you please pull this and update pub? Thanks :-)