### PR TITLE
Fix %f with zero fractional part when compiled to javascript

### DIFF
--- a/lib/src/formatters/float_formatter.dart
+++ b/lib/src/formatters/float_formatter.dart
@@ -2,7 +2,7 @@ part of sprintf;
 
 class FloatFormatter extends Formatter {
   // TODO: can't rely on '.' being the decimal separator
-  static final _number_rx = new RegExp(r'^[\-\+]?(\d+)\.(\d+)$');
+  static final _number_rx = new RegExp(r'^[\-\+]?(\d+)(?:\.(\d+))?$');
   static final _expo_rx = new RegExp(r'^[\-\+]?(\d)\.(\d+)e([\-\+]?\d+)$');
   static final _leading_zeroes_rx = new RegExp(r'^(0*)[1-9]+');
 
@@ -27,6 +27,9 @@ class FloatFormatter extends Formatter {
     if (m1 != null) {
       String int_part = m1.group(1);
       String fraction = m1.group(2);
+
+      if(fraction == null)
+          fraction = "0";
 
       /*
        * Cases:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sprintf
-version: 3.0.2
+version: 3.0.2+1
 author: Richard Eames <dartsprintf@naddiseo.ca>
 description: Dart implementation of sprintf
 homepage: https://github.com/Naddiseo/dart-sprintf


### PR DESCRIPTION
Hello,
please consider merging this patch, I always get ",--" when formatting numbers like 10, 20, 30 using %.2f by production javascript code generated from dart sources.
